### PR TITLE
Emphasize that there is a list of AZs in an Auto Scaling group

### DIFF
--- a/doc_source/attach-instance-asg.md
+++ b/doc_source/attach-instance-asg.md
@@ -6,7 +6,7 @@ The instance that you want to attach must meet the following criteria:
 + The instance is in the `running` state\.
 + The AMI used to launch the instance must still exist\.
 + The instance is not a member of another Auto Scaling group\.
-+ The instance is in the same Availability Zone as the Auto Scaling group\.
++ The Availability Zone of the instance is in the list of Availability Zones declared in the Auto Scaling group\.
 + If the Auto Scaling group has an attached load balancer, the instance and the load balancer must both be in EC2\-Classic or the same VPC\. If the Auto Scaling group has an attached target group, the instance and the load balancer must both be in the same VPC\.
 
 When you attach instances, the desired capacity of the group increases by the number of instances being attached\. If the number of instances being attached plus the desired capacity exceeds the maximum size of the group, the request fails\.

--- a/doc_source/attach-instance-asg.md
+++ b/doc_source/attach-instance-asg.md
@@ -6,7 +6,7 @@ The instance that you want to attach must meet the following criteria:
 + The instance is in the `running` state\.
 + The AMI used to launch the instance must still exist\.
 + The instance is not a member of another Auto Scaling group\.
-+ The Availability Zone of the instance is in the list of Availability Zones declared in the Auto Scaling group\.
++ The instance is launched into one of the Availability Zones defined in your Auto Scaling group\.
 + If the Auto Scaling group has an attached load balancer, the instance and the load balancer must both be in EC2\-Classic or the same VPC\. If the Auto Scaling group has an attached target group, the instance and the load balancer must both be in the same VPC\.
 
 When you attach instances, the desired capacity of the group increases by the number of instances being attached\. If the number of instances being attached plus the desired capacity exceeds the maximum size of the group, the request fails\.


### PR DESCRIPTION

*Issue #, if available:* 
Clarified one of the criteria of attaching an EC2 instance to an Auto Scaling group. 

*Description of changes:*

The statement that says: **_"The instance is in the same Availability Zone as the Auto Scaling group"_**, seems to convey that an Auto Scaling group can ONLY handle instances in the same, or in a single, Availability Zone which is entirely false. Take note that an Auto Scaling group can control instances in one or more Availability Zones as per this document: https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-availability-zone.html

That statement might give a false impression that the scope of an Auto Scaling group is limited within a single Availability Zone. I would like to propose to change this to the one below, to emphasize that there is a list of AZs in an Auto Scaling group:

**_"The Availability Zone of the instance is in the list of Availability Zones declared in the Auto Scaling group."_**


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
