### PR TITLE
Fix Incorrect Bracket Matching and Empty space characters on lifecycle-hooks.md page

### DIFF
--- a/doc_source/lifecycle-hooks.md
+++ b/doc_source/lifecycle-hooks.md
@@ -2,9 +2,9 @@
 
 Lifecycle hooks enable you to perform custom actions by *pausing* instances as an Auto Scaling group launches or terminates them\. When an instance is paused, it remains in a wait state either until you complete the lifecycle action using the complete\-lifecycle\-action command or the `CompleteLifecycleAction` operation, or until the timeout period ends \(one hour by default\)\.
 
-For example, let's say that your newly launched instance completes its startup sequence and a lifecycle hook pauses the instance\. While the instance is in a wait state, you can install or configure software on it, making sure that your instance is fully ready before it starts receiving traffic\. For another example of the use of lifecycle hooks, let's say that when a scale\-in event occurs, the terminating instance is first deregistered from the load balancer \(if the Auto Scaling group is being used with Elastic Load Balancing\)\. Then, a lifecycle hook pauses the instance before it is terminated\. While the instance is in the wait state, you can, for example, connect to the instance and download logs or other data before the instance is fully terminated\. 
+For example, let's say that your newly launched instance completes its startup sequence and a lifecycle hook pauses the instance\. While the instance is in a wait state, you can install or configure software on it, making sure that your instance is fully ready before it starts receiving traffic\. For another example of the use of lifecycle hooks, let's say that when a scale\-in event occurs, the terminating instance is first deregistered from the load balancer \(if the Auto Scaling group is being used with Elastic Load Balancing\)\. Then, a lifecycle hook pauses the instance before it is terminated\. While the instance is in the wait state, you can, for example, connect to the instance and download logs or other data before the instance is fully terminated\.
 
-Each Auto Scaling group can have multiple lifecycle hooks\. However, there is a limit on the number of hooks per Auto Scaling group\. For more information, see [Amazon EC2 Auto Scaling Service Quotas](as-account-limits.md)\. 
+Each Auto Scaling group can have multiple lifecycle hooks\. However, there is a limit on the number of hooks per Auto Scaling group\. For more information, see [Amazon EC2 Auto Scaling Service Quotas](as-account-limits.md)\.
 
 **Topics**
 + [How Lifecycle Hooks Work](#lifecycle-hooks-overview)
@@ -65,11 +65,11 @@ You can use lifecycle hooks with Spot Instances\. However, a lifecycle hook does
 
 You can configure notifications for when an instance enters a wait state\. You can use Amazon EventBridge, Amazon SNS, or Amazon SQS to receive the notifications\. For more information, see [Configuring Lifecycle Hook Notifications](configuring-lifecycle-hook-notifications.md)\.
 
-Alternatively, if you have a script that configures your instances when they launch, you do not need to receive notification when the lifecycle action occurs\. If you are not doing so already, update your script to retrieve the instance ID of the instance from the instance metadata\. For more information, see [Retrieving Instance Metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-retrieval) in the *Amazon EC2 User Guide for Linux Instances*\. 
+Alternatively, if you have a script that configures your instances when they launch, you do not need to receive notification when the lifecycle action occurs\. If you are not doing so already, update your script to retrieve the instance ID of the instance from the instance metadata\. For more information, see [Retrieving Instance Metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-retrieval) in the *Amazon EC2 User Guide for Linux Instances*\.
 
 ## Add Lifecycle Hooks<a name="adding-lifecycle-hooks"></a>
 
-When you add a lifecycle hook to your Auto Scaling group, you can specify whether it should be run when instances launch or terminate in the Auto Scaling group\. 
+When you add a lifecycle hook to your Auto Scaling group, you can specify whether it should be run when instances launch or terminate in the Auto Scaling group\.
 
 **Topics**
 + [Add Lifecycle Hooks \(Console\)](#adding-lifecycle-hooks-console)
@@ -87,27 +87,27 @@ Follow these steps to add a lifecycle hook to an existing Auto Scaling group\. Y
 
 1. Select the check box next to your Auto Scaling group\.
 
-   A split pane opens up in the bottom part of the **Auto Scaling groups** page, showing information about the group that's selected\. 
+   A split pane opens up in the bottom part of the **Auto Scaling groups** page, showing information about the group that's selected\.
 
-1. On the **Instance management** tab, in **Lifecycle hooks**, choose **Create lifecycle hook**\. \(Old console: The **Lifecycle Hooks** tab is where you can create a lifecycle hook\.\) 
+1. On the **Instance management** tab, in **Lifecycle hooks**, choose **Create lifecycle hook**\. \(Old console: The **Lifecycle Hooks** tab is where you can create a lifecycle hook\.\)
 
 1. To define a lifecycle hook, do the following:
 
    1. For **Lifecycle hook name**, specify a name for the lifecycle hook\.
 
-   1. For **Lifecycle transition**, choose **Instance launch** or **Instance terminate**\. 
+   1. For **Lifecycle transition**, choose **Instance launch** or **Instance terminate**\.
 
-   1. Specify a timeout value for **Heartbeat timeout**, which allows you to control the amount of time for the instances to remain in a wait state\. The value must be from 30 to 7200 seconds\. During the timeout period, you can, for example, log on to a newly launched instance, and install applications or perform custom actions\. 
+   1. Specify a timeout value for **Heartbeat timeout**, which allows you to control the amount of time for the instances to remain in a wait state\. The value must be from 30 to 7200 seconds\. During the timeout period, you can, for example, log on to a newly launched instance, and install applications or perform custom actions\.
 
    1. For **Default result**, specify the action that the Auto Scaling group takes when the lifecycle hook timeout elapses or if an unexpected failure occurs\. You can choose to either ABANDON or CONTINUE\.
 
       If the instance is launching, CONTINUE indicates that your actions were successful, and that the Auto Scaling group can put the instance into service\. Otherwise, ABANDON indicates that your custom actions were unsuccessful, and that Auto Scaling can terminate the instance\. If the instance is terminating, both ABANDON and CONTINUE allow the instance to terminate\. However, ABANDON stops any remaining actions, such as other lifecycle hooks, and CONTINUE allows any other lifecycle hooks to complete\.
 
-   1. \(Optional\) For **Notification metadata**, specify additional information that you want to include any time that Amazon EC2 Auto Scaling sends a message to the notification target\. 
+   1. \(Optional\) For **Notification metadata**, specify additional information that you want to include any time that Amazon EC2 Auto Scaling sends a message to the notification target\.
 
 1. Choose **Create**\.
 
-### Add Lifecycle Hooks \(AWS CLI\}<a name="adding-lifecycle-hooks-aws-cli"></a>
+### Add Lifecycle Hooks \(AWS CLI\)<a name="adding-lifecycle-hooks-aws-cli"></a>
 
 Create and update lifecycle hooks using the [https://docs.aws.amazon.com/cli/latest/reference/autoscaling/put-lifecycle-hook.html](https://docs.aws.amazon.com/cli/latest/reference/autoscaling/put-lifecycle-hook.html) command\.
 
@@ -125,7 +125,7 @@ aws autoscaling put-lifecycle-hook --lifecycle-hook-name my-hook --auto-scaling-
   --lifecycle-transition autoscaling:EC2_INSTANCE_TERMINATING
 ```
 
-To receive notifications using Amazon SNS or Amazon SQS, you must specify a notification target and an IAM role\. For more information, see [Configuring Notifications for Amazon EC2 Auto Scaling Lifecycle Hooks](configuring-lifecycle-hook-notifications.md)\. 
+To receive notifications using Amazon SNS or Amazon SQS, you must specify a notification target and an IAM role\. For more information, see [Configuring Notifications for Amazon EC2 Auto Scaling Lifecycle Hooks](configuring-lifecycle-hook-notifications.md)\.
 
 For example, add the following options to specify an SNS topic as the notification target\.
 
@@ -189,7 +189,7 @@ To generate a notification for a launch event, update the Auto Scaling group by 
 
 1. Select the check box next to your Auto Scaling group\.
 
-   A split pane opens up in the bottom part of the **Auto Scaling groups** page, showing information about the group that's selected\. 
+   A split pane opens up in the bottom part of the **Auto Scaling groups** page, showing information about the group that's selected\.
 
 1. On the **Details** tab, choose **Group details**, **Edit**\. \(Old console: On the **Details** tab, choose **Edit**\.\)
 


### PR DESCRIPTION
**Description**

- Fixed incorrect bracket matching in the section `Add Lifecycle Hooks` of lifecycle-hooks.md.
- The bracket sequence is changed from `(}` to correct sequence of `()`.
- While fixing the above, found that many lines in the documentation ended with empty space, hence also corrected those lines and removed empty space at the end.