### PR TITLE
Update key-policy-requirements-EBS-encryption.md

### DIFF
--- a/doc_source/key-policy-requirements-EBS-encryption.md
+++ b/doc_source/key-policy-requirements-EBS-encryption.md
@@ -136,7 +136,7 @@ For this command to succeed, the user making the request must have permissions f
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "Allow creation of grant for the CMK in external account 444455556666",
+      "Sid": "AllowCreationOfGrantForTheCMKinExternalAccount444455556666",
       "Effect": "Allow",
       "Action": "kms:CreateGrant",
       "Resource": "arn:aws:kms:us-west-2:444455556666:key/1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"


### PR DESCRIPTION
Removed spaces in the example IAM policy that grants access for the CMK in the external account, since spaces are not allowed in SID strings.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
