### PR TITLE
Update attach-instance-asg.md

### DIFF
--- a/doc_source/attach-instance-asg.md
+++ b/doc_source/attach-instance-asg.md
@@ -1,8 +1,8 @@
 # Attach EC2 instances to your Auto Scaling group<a name="attach-instance-asg"></a>
 
-Amazon EC2 Auto Scaling provides you with an option to enable automatic scaling for one or more EC2 instances by attaching them to your existing Auto Scaling group\. After the instances are attached, they become a part of the Auto Scaling group\.
+Amazon EC2 Auto Scaling provides you with the option of attaching one or more EC2 instances to your existing Auto Scaling group. After an instance is attached, it is considered part of the Auto Scaling group.
 
-The instance to attach must meet the following criteria:
+For an instance to be attached, it must meet the following criteria:
 + The instance is in the `running` state\.
 + The AMI used to launch the instance must still exist\.
 + The instance is not a member of another Auto Scaling group\.


### PR DESCRIPTION
Attaching a EC2 instance to a Auto Scaling group is a manual process, so I don’t think it is correct to describe it as “an option to enable automatic scaling” 
In the second sentence it is better to use the singular, and the word “considered” is a little better than “become”. 
On line #5 the phrase "The instance to attach" is a little awkward. It is slightly better as "For an instance to be attached," 

Thank you for taking the time to review my proposed changes. 
-Brian

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
