### PR TITLE
Update tutorial-lifecycle-hook-lambda.md

### DIFF
--- a/doc_source/tutorial-lifecycle-hook-lambda.md
+++ b/doc_source/tutorial-lifecycle-hook-lambda.md
@@ -100,7 +100,7 @@ Create a Lambda function to serve as the target for events\. The sample Lambda f
            AutoScalingGroupName: eventDetail['AutoScalingGroupName'], /* required */
            LifecycleActionResult: 'CONTINUE', /* required */
            LifecycleHookName: eventDetail['LifecycleHookName'], /* required */
-           InstanceId: eventDetail['InstanceId'],
+           InstanceId: eventDetail['EC2InstanceId'],
            LifecycleActionToken: eventDetail['LifecycleActionToken']
        };
        var response; 


### PR DESCRIPTION
The actual payload of the event has instance id with property "EC2InstanceId" instead of "InstanceId"
See the event details here https://docs.aws.amazon.com/autoscaling/ec2/userguide/cloud-watch-events.html#terminate-lifecycle-action

*Issue #, if available:*

*Description of changes:*
Example code uses a wrong property based on the latest documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
