### PR TITLE
Update predictive-scaling-customized-metric-specification.md

### DIFF
--- a/doc_source/predictive-scaling-customized-metric-specification.md
+++ b/doc_source/predictive-scaling-customized-metric-specification.md
@@ -146,78 +146,78 @@ aws autoscaling put-scaling-policy --policy-name my-sqs-custom-metrics-policy \
   --auto-scaling-group-name my-asg --policy-type PredictiveScaling \
   --predictive-scaling-configuration file://config.json
 {
-  "MetricSpecifications": [
-    {
-      "TargetValue": 100,
-      "CustomizedScalingMetricSpecification": {
-        "MetricDataQueries": [
-          {
-            "Label": "Get the queue size (the number of messages waiting to be processed)",
-            "Id": "queue_size",
-            "MetricStat": {
-              "Metric": {
-                "MetricName": "ApproximateNumberOfMessagesVisible",
-                "Namespace": "AWS/SQS",
-                "Dimensions": [
-                  {
-                    "Name": "QueueName",
-                    "Value": "my-queue"
-                  }
+    "MetricSpecifications": [
+        {
+            "TargetValue": 100,
+            "CustomizedScalingMetricSpecification": {
+                "MetricDataQueries": [
+                    {
+                        "Label": "Get the queue size (the number of messages waiting to be processed)",
+                        "Id": "queue_size",
+                        "MetricStat": {
+                            "Metric": {
+                                "MetricName": "ApproximateNumberOfMessagesVisible",
+                                "Namespace": "AWS/SQS",
+                                "Dimensions": [
+                                    {
+                                        "Name": "QueueName",
+                                        "Value": "my-queue"
+                                    }
+                                ]
+                            },
+                            "Stat": "Sum"
+                        },
+                        "ReturnData": false
+                    },
+                    {
+                        "Label": "Get the group size (the number of running instances)",
+                        "Id": "running_capacity",
+                        "MetricStat": {
+                            "Metric": {
+                                "MetricName": "GroupInServiceInstances",
+                                "Namespace": "AWS/AutoScaling",
+                                "Dimensions": [
+                                    {
+                                        "Name": "AutoScalingGroupName",
+                                        "Value": "my-asg"
+                                    }
+                                ]
+                            },
+                            "Stat": "Sum"
+                        },
+                        "ReturnData": false
+                    },
+                    {
+                        "Label": "Calculate the backlog per instance",
+                        "Id": "scaling_metric",
+                        "Expression": "queue_size / running_capacity",
+                        "ReturnData": true
+                    }
                 ]
-              },
-              "Stat": "Sum"
             },
-            "ReturnData": false
-          },
-          {
-            "Label": "Get the group size (the number of running instances)",
-            "Id": "running_capacity",
-            "MetricStat": {
-              "Metric": {
-                "MetricName": "GroupInServiceInstances",
-                "Namespace": "AWS/AutoScaling",
-                "Dimensions": [
-                  {
-                    "Name": "AutoScalingGroupName",
-                    "Value": "my-asg"
-                  }
+            "CustomizedLoadMetricSpecification": {
+                "MetricDataQueries": [
+                    {
+                        "Id": "load_metric",
+                        "MetricStat": {
+                            "Metric": {
+                                "MetricName": "ApproximateNumberOfMessagesVisible",
+                                "Namespace": "AWS/SQS",
+                                "Dimensions": [
+                                    {
+                                        "Name": "QueueName",
+                                        "Value": "my-queue"
+                                    }
+                                ]
+                            },
+                            "Stat": "Sum"
+                        },
+                        "ReturnData": true
+                    }
                 ]
-              },
-              "Stat": "Sum"
-            },
-            "ReturnData": false
-          },
-          {
-            "Label": "Calculate the backlog per instance",
-            "Id": "scaling_metric",
-            "Expression": "queue_size / running_capacity",
-            "ReturnData": true
-          }
-        ]
-      },
-      "CustomizedLoadMetricSpecification": {
-        "MetricDataQueries": [
-          {
-            "Id": "load_metric",
-            "MetricStat": {
-              "Metric": {
-                "MetricName": "ApproximateNumberOfMessagesVisible",
-                "Namespace": "AWS/SQS",
-                "Dimensions": [
-                  {
-                    "Name": "QueueName",
-                    "Value": "my-queue"
-                  }
-                ],
-                "Stat": "Sum"
-              }
-            },
-            "ReturnData": true
-          }
-        ]
-      }
-    }
-  ]
+            }
+        }
+    ]
 }
 ```
 


### PR DESCRIPTION
fix the config.json part of "Example predictive scaling policy that combines metrics using metric math"

*Issue #, if available:*
The third "Stat": "Sum" needs to be outside of "Metric".

*Description of changes:*
Fixed it. Verified the new json can create the policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
