### PR TITLE
update dimensions list to table format

### DIFF
--- a/doc_source/as-instance-monitoring.md
+++ b/doc_source/as-instance-monitoring.md
@@ -116,7 +116,7 @@ The `AWS/AutoScaling` namespace includes the following metrics for Auto Scaling 
 |  GroupAndWarmPoolDesiredCapacity  |  The desired capacity of the Auto Scaling group and the warm pool combined\. **Reporting criteria**: Reported if metrics collection is enabled\.  | 
 |  GroupAndWarmPoolTotalCapacity  |  The total capacity of the Auto Scaling group and the warm pool combined\. This includes instances that are running, stopped, pending, terminating, or in service\.  **Reporting criteria**: Reported if metrics collection is enabled\.  | 
 
-### Dimensions for Auto Scaling group metrics<a name="as-group-metric-dimensions"></a>
+### Auto Scaling group dimensions<a name="as-group-metric-dimensions"></a>
 
 | Dimension | Description | 
 | --- | --- | 

--- a/doc_source/as-instance-monitoring.md
+++ b/doc_source/as-instance-monitoring.md
@@ -118,7 +118,10 @@ The `AWS/AutoScaling` namespace includes the following metrics for Auto Scaling 
 
 ### Dimensions for Auto Scaling group metrics<a name="as-group-metric-dimensions"></a>
 
-To filter the metrics for your Auto Scaling group by group name, use the `AutoScalingGroupName` dimension\.
+| Dimension | Description | 
+| --- | --- | 
+| AutoScalingGroupName | Filter metric for a specific Auto Scaling group by name\. |
+
 
 ## Working with Amazon CloudWatch<a name="cloudwatch-working"></a>
 


### PR DESCRIPTION
Updated the dimensions for Auto Scaling groups to table format to align with other AWS Services documentation on CloudWatch metrics (e.g.:  https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
