### PR TITLE
Correct example in lambda-custom-termination-policy.md

### DIFF
--- a/doc_source/lambda-custom-termination-policy.md
+++ b/doc_source/lambda-custom-termination-policy.md
@@ -29,17 +29,17 @@ The following is an example payload:
     {
       "AvailabilityZone": "us-east-1b",
       "Capacity": 2,
-      "InstanceMarketOption": "OnDemand"
+      "InstanceMarketOption": "on-demand"
     },
     {
       "AvailabilityZone": "us-east-1b",
       "Capacity": 1,
-      "InstanceMarketOption": "Spot"
+      "InstanceMarketOption": "spot"
     },
     {
       "AvailabilityZone": "us-east-1c",
       "Capacity": 3,
-      "InstanceMarketOption": "OnDemand"
+      "InstanceMarketOption": "on-demand"
     }
   ],
   "Instances": [
@@ -47,19 +47,19 @@ The following is an example payload:
       "AvailabilityZone": "us-east-1b",
       "InstanceId": "i-0056faf8da3e1f75d",
       "InstanceType": "t2.nano",
-      "InstanceMarketOption": "OnDemand"
+      "InstanceMarketOption": "on-demand"
     },
     {
       "AvailabilityZone": "us-east-1c",
       "InstanceId": "i-02e1c69383a3ed501",
       "InstanceType": "t2.nano",
-      "InstanceMarketOption": "OnDemand"
+      "InstanceMarketOption": "on-demand"
     },
     {
       "AvailabilityZone": "us-east-1c",
       "InstanceId": "i-036bc44b6092c01c7",
       "InstanceType": "t2.nano",
-      "InstanceMarketOption": "OnDemand"
+      "InstanceMarketOption": "on-demand"
     },
     ...
   ],


### PR DESCRIPTION
### SUMMARY

Update example to show that `InstanceMarketOption` values are `spot` or `on-demand` (not `Spot | OnDemand`).

See example event request received from an Auto Scaling Group Scale In Event, as of May 2022:

```json
{
    "AutoScalingGroupARN": "<redacted>",
    "AutoScalingGroupName": "<redacted>",
    "CapacityToTerminate": [
        {
            "AvailabilityZone": "us-west-2a",
            "Capacity": 1,
            "InstanceMarketOption": "on-demand"
        },
        {
            "AvailabilityZone": "us-west-2b",
            "Capacity": 1,
            "InstanceMarketOption": "on-demand"
        }
    ],
    "Instances": [
        {
            "AvailabilityZone": "us-west-2b",
            "InstanceId": "<redacted>",
            "InstanceType": "c5.xlarge",
            "InstanceMarketOption": "on-demand"
        },
        {
            "AvailabilityZone": "us-west-2a",
            "InstanceId": "<redacted>",
            "InstanceType": "c5.xlarge",
            "InstanceMarketOption": "on-demand"
        }
    ],
    "Cause": "SCALE_IN"
}
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
